### PR TITLE
Use `pip download` to download packages

### DIFF
--- a/robotpy_installer/installer.py
+++ b/robotpy_installer/installer.py
@@ -1007,9 +1007,8 @@ class RobotpyInstaller(object):
         if len(options.requirement) == 0 and len(options.packages) == 0:
             raise ArgError("You must give at least one requirement to install")
 
-        # Use pip install --download to put packages into the cache
-        pip_args = ['install',
-                    '--download',
+        # Use pip download to put packages into the cache
+        pip_args = ['download',
                     self.pip_cache]
 
         pip_args.extend(self._process_pip_args(options))


### PR DESCRIPTION
I noticed that `pip install --download` is now deprecated. Hope this is helpful!