### PR TITLE
More deploy updates

### DIFF
--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -420,6 +420,21 @@ class Deploy:
                     for package in packages:
                         logger.info("- %s", package)
 
+                    # Check if everything is in the cache before doing the install
+                    cached = pypackages.get_pip_cache_packages(installer.cache_root)
+                    ok, missing = project.are_requirements_met(
+                        cached, pypackages.roborio_env()
+                    )
+                    if not ok:
+                        errmsg = ["Project requirements not found in download cache!"]
+                        errmsg.extend([f"- {msg}" for msg in missing])
+                        errmsg += [
+                            "",
+                            "Run 'python -m robotpy sync' to download your project requirements",
+                            "from the internet (or specify --no-install to not attempt installation).",
+                        ]
+                        raise Error("\n".join(errmsg))
+
                     try:
                         installer.pip_install(False, False, False, False, [], packages)
                     except PipInstallError as e:

--- a/robotpy_installer/cli_installer.py
+++ b/robotpy_installer/cli_installer.py
@@ -3,7 +3,7 @@ import pathlib
 import shutil
 import typing
 
-from . import roborio_utils
+from . import pypackages, roborio_utils
 from .utils import handle_cli_error
 
 from .installer import (
@@ -73,6 +73,21 @@ class InstallerCacheLocation:
         print(installer.cache_root)
 
 
+class InstallerCacheList:
+    """List python packages in cache"""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        pass
+
+    @handle_cli_error
+    def run(self):
+        installer = RobotpyInstaller(log_startup=False)
+        packages = pypackages.get_pip_cache_packages(installer.cache_root)
+        for pkg in sorted(packages.keys()):
+            versions = map(str, sorted(packages[pkg]))
+            print(f"{pkg}: {' '.join(versions)}")
+
+
 class InstallerCacheRm:
     """Delete all cached files"""
 
@@ -99,6 +114,7 @@ class InstallerCache:
 
     subcommands = [
         ("location", InstallerCacheLocation),
+        ("list", InstallerCacheList),
         ("rm", InstallerCacheRm),
     ]
 

--- a/robotpy_installer/installer.py
+++ b/robotpy_installer/installer.py
@@ -581,6 +581,9 @@ class RobotpyInstaller:
             else:
                 pip_args.append(package)
 
+        # pip is greedy
+        self.ensure_more_memory()
+
         try:
             self.ssh.exec_cmd(shlex.join(pip_args), check=True, print_output=True)
         except SshExecError as e:
@@ -592,6 +595,9 @@ class RobotpyInstaller:
 
     def pip_list(self):
         self.ensure_robot_pip()
+
+        # pip is greedy
+        self.ensure_more_memory()
 
         with catch_ssh_error("pip3 list"):
             self.ssh.exec_cmd(
@@ -617,6 +623,9 @@ class RobotpyInstaller:
             "--yes",
         ]
         pip_args.extend(packages)
+
+        # pip is greedy
+        self.ensure_more_memory()
 
         with catch_ssh_error("uninstalling packages"):
             self.ssh.exec_cmd(shlex.join(pip_args), check=True, print_output=True)

--- a/robotpy_installer/pypackages.py
+++ b/robotpy_installer/pypackages.py
@@ -1,0 +1,104 @@
+"""
+Various python packaging related logic
+"""
+
+from importlib.metadata import distributions
+import pathlib
+import typing
+
+from packaging.requirements import Requirement
+from packaging.utils import (
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+    NormalizedName,
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+)
+from packaging.version import Version
+
+#: environment markers needed by Marker.evaluate
+Env = typing.Dict[str, str]
+
+Packages = typing.Dict[NormalizedName, typing.List[Version]]
+
+
+def are_requirements_met(
+    requirements: typing.List[Requirement],
+    packages: Packages,
+    env: Env,
+) -> typing.Tuple[bool, typing.List[str]]:
+    """
+    Given a set of packages and a list of requirements, determine if the packages
+    satisfy the list of requirements
+    """
+
+    unmet_requirements = []
+
+    for req in requirements:
+        # Ignore this requirement if it doesn't apply to the specified
+        # environment
+        if req.marker and not req.marker.evaluate(env):
+            continue
+
+        req_name = canonicalize_name(req.name)
+
+        empty_specifier = str(req.specifier) == ""
+
+        for pkg, pkg_versions in packages.items():
+            if pkg == req_name:
+                if not empty_specifier:
+                    for pkg_version in pkg_versions:
+                        if pkg_version in req.specifier:
+                            break
+                    else:
+                        found = ", ".join(map(str, sorted(pkg_versions)))
+                        unmet_requirements.append(
+                            f"{req.name}{req.specifier} (found {found})"
+                        )
+                break
+        else:
+            unmet_requirements.append(f"{req.name}{req.specifier} (not found)")
+
+    return not bool(unmet_requirements), unmet_requirements
+
+
+def get_local_packages() -> Packages:
+    """
+    Iterates over locally installed packages and returns dict of versions
+    """
+    return {
+        canonicalize_name(dist.metadata["Name"]): [Version(dist.version)]
+        for dist in distributions()
+    }
+
+
+def make_packages(
+    packages: typing.Mapping[str, typing.Union[typing.List[str], str]]
+) -> Packages:
+    """
+    For unit testing
+    """
+    return {
+        canonicalize_name(name): [Version(version)]
+        if isinstance(version, str)
+        else [Version(v) for v in version]
+        for name, version in packages.items()
+    }
+
+
+def roborio_env() -> Env:
+    """
+    For use with ``packaging.marker.Marker.evaluate``
+    """
+    return {
+        "implementation_name": "cpython",
+        "implementation_version": "3.12.1",
+        "os_name": "posix",
+        "platform_machine": "roborio",
+        "platform_python_implementation": "CPython",
+        "platform_system": "Linux",
+        "python_full_version": "3.12.0",
+        "python_version": "3.12",
+        "sys_platform": "linux",
+    }

--- a/robotpy_installer/pypackages.py
+++ b/robotpy_installer/pypackages.py
@@ -73,6 +73,32 @@ def get_local_packages() -> Packages:
     }
 
 
+def get_pip_cache_packages(
+    cache_root: pathlib.Path,
+) -> Packages:
+    """
+    Iterates over the pip cache and returns dict of packages
+    """
+
+    packages: Packages = {}
+
+    for f in (cache_root / "pip_cache").iterdir():
+        if f.suffix == ".whl":
+            try:
+                name, version, _, _ = parse_wheel_filename(f.name)
+                packages.setdefault(name, []).append(version)
+            except InvalidWheelFilename:
+                pass
+        elif f.suffix in (".gz", ".zip"):
+            try:
+                name, version = parse_sdist_filename(f.name)
+                packages.setdefault(name, []).append(version)
+            except InvalidSdistFilename:
+                pass
+
+    return packages
+
+
 def make_packages(
     packages: typing.Mapping[str, typing.Union[typing.List[str], str]]
 ) -> Packages:

--- a/robotpy_installer/pyproject.py
+++ b/robotpy_installer/pyproject.py
@@ -76,9 +76,7 @@ class RobotPyProjectToml:
         Determines if the set of packages meets the requirements specified by
         this project
         """
-        return pypackages.are_requirements_met(
-            [self.robotpy_requires] + self.requires, packages, env
-        )
+        return pypackages.are_requirements_met(self.get_install_reqs(), packages, env)
 
     def are_local_requirements_met(
         self,
@@ -90,10 +88,11 @@ class RobotPyProjectToml:
 
         return self.are_requirements_met(pypackages.get_local_packages(), {})
 
+    def get_install_reqs(self) -> typing.List[Requirement]:
+        return [self.robotpy_requires] + self.requires
+
     def get_install_list(self) -> typing.List[str]:
-        packages = [str(self.robotpy_requires)]
-        packages.extend([str(req) for req in self.requires])
-        return packages
+        return list(map(str, self.get_install_reqs()))
 
 
 def robotpy_installed_version() -> str:

--- a/robotpy_installer/pyproject.py
+++ b/robotpy_installer/pyproject.py
@@ -71,12 +71,20 @@ class RobotPyProjectToml:
         self,
         packages: Packages,
         env: Env,
+        extra_resolver: pypackages.ExtraResolver,
     ) -> typing.Tuple[bool, typing.List[str]]:
         """
         Determines if the set of packages meets the requirements specified by
         this project
         """
-        return pypackages.are_requirements_met(self.get_install_reqs(), packages, env)
+        reqs = self.get_install_reqs()
+        assert reqs and reqs[0].name == "robotpy"
+        robotpy_req = reqs[0]
+
+        # Extra requirements from the extra resolver
+        reqs.extend(extra_resolver(robotpy_req, env))
+
+        return pypackages.are_requirements_met(reqs, packages, env)
 
     def are_local_requirements_met(
         self,
@@ -86,7 +94,9 @@ class RobotPyProjectToml:
         specified by this project
         """
 
-        return self.are_requirements_met(pypackages.get_local_packages(), {})
+        return self.are_requirements_met(
+            pypackages.get_local_packages(), {}, pypackages.extra_resolver_local
+        )
 
     def get_install_reqs(self) -> typing.List[Requirement]:
         return [self.robotpy_requires] + self.requires

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,10 +1,17 @@
 import inspect
+import typing
 
 from robotpy_installer import pyproject, pypackages
+
+from packaging.requirements import Requirement
 
 
 def load_project(content: str) -> pyproject.RobotPyProjectToml:
     return pyproject.loads(inspect.cleandoc(content))
+
+
+def null_resolver(req: Requirement, env: pypackages.Env) -> typing.List[Requirement]:
+    return []
 
 
 def test_ok():
@@ -15,7 +22,9 @@ def test_ok():
     """
     )
     installed = pypackages.make_packages({"robotpy": "2024.1.1.2"})
-    assert project.are_requirements_met(installed, pypackages.roborio_env()) == (
+    assert project.are_requirements_met(
+        installed, pypackages.roborio_env(), null_resolver
+    ) == (
         True,
         [],
     )
@@ -29,7 +38,9 @@ def test_older_fail():
     """
     )
     installed = pypackages.make_packages({"robotpy": "2024.1.1.0"})
-    assert project.are_requirements_met(installed, pypackages.roborio_env()) == (
+    assert project.are_requirements_met(
+        installed, pypackages.roborio_env(), null_resolver
+    ) == (
         False,
         ["robotpy==2024.1.1.2 (found 2024.1.1.0)"],
     )
@@ -43,7 +54,9 @@ def test_older_and_newer_fail():
     """
     )
     installed = pypackages.make_packages({"robotpy": ["2024.1.1.0", "2024.1.1.4"]})
-    assert project.are_requirements_met(installed, pypackages.roborio_env()) == (
+    assert project.are_requirements_met(
+        installed, pypackages.roborio_env(), null_resolver
+    ) == (
         False,
         ["robotpy==2024.1.1.2 (found 2024.1.1.0, 2024.1.1.4)"],
     )
@@ -64,7 +77,9 @@ def test_beta_empty_req():
         {"robotpy": "2024.1.1.2", "robotpy-commands-v2": "2024.0.0b4"}
     )
 
-    assert project.are_requirements_met(installed, pypackages.roborio_env()) == (
+    assert project.are_requirements_met(
+        installed, pypackages.roborio_env(), null_resolver
+    ) == (
         True,
         [],
     )
@@ -86,7 +101,9 @@ def test_env_marker():
         {"robotpy": "2024.1.1.2", "robotpy-opencv": "2024.0.0"}
     )
 
-    assert project.are_requirements_met(installed, pypackages.roborio_env()) == (
+    assert project.are_requirements_met(
+        installed, pypackages.roborio_env(), null_resolver
+    ) == (
         True,
         [],
     )


### PR DESCRIPTION
- Fixes #80
- Fixes #82
- Fixes #88

This is neat because the fix for 80 allows you to add things like this in `pyproject.toml` to indicate that you want something installed on or off robot:

```toml
requires = [
    "robotpy-opencv; platform_machine == 'roborio'",
    "opencv-python; platform_machine != 'roborio'"
]
```

This also fixes the robotpy_extras stuff such that if you delete an item from the list or add an item from the list it will notice and install the correct requirements now.

Finally, this has a dangerous thing that uninstalls everything from the rio if an install is going to happen on deploy. It's correct, and we check to see if the user has stuff in their cache so it shouldn't break the rio... but really I'd rather only uninstall the things that aren't in the user's requirements... but we'd have to do a full dependency resolving which sounds really obnoxious and error-prone.

... though, we could write a script that does it on the rio, instead of trying to figure it out by inspecting wheels. That might not be too bad?
