### PR TITLE
Default pyproject.toml robotpy_extras list needs commas

### DIFF
--- a/robotpy_installer/pyproject.py
+++ b/robotpy_installer/pyproject.py
@@ -132,7 +132,7 @@ def write_default_pyproject(
     if not provides_extra:
         extras = ""
     else:
-        extras = "\n    # ".join(f'"{extra}"' for extra in sorted(provides_extra))
+        extras = "\n    # ".join(f'"{extra}",' for extra in sorted(provides_extra))
 
     content = inspect.cleandoc(
         f"""


### PR DESCRIPTION
This is a small usability improvement.  The robotpy init subcommand now adds commas between the list elements in the robotpy_extras list when creating a new pyproject.toml file.

Old:
--------
robotpy_extras = [
    # "all"
    # "apriltag"
    # "commands2"
    ...
]

New:
--------
robotpy_extras = [
    # "all",
    # "apriltag",
    # "commands2",
    ...
]

I verified that pytest passes.