### PR TITLE
deploy: Exclude ctre_sim directory

### DIFF
--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -655,7 +655,7 @@ class Deploy:
 
             # skip .svn, .git, .hg, etc directories
             for d in dirs[:]:
-                if d.startswith(".") or d in ("__pycache__", "venv"):
+                if d.startswith(".") or d in ("__pycache__", "ctre_sim", "venv"):
                     dirs.remove(d)
 
             # skip .pyc files


### PR DESCRIPTION
This directory is created by CTRE Phoenix sim devices, and is gitignored by the WPILib template: https://github.com/wpilibsuite/vscode-wpilib/blob/7f0180f7a3aeaded52beccba2f33481834f593f2/vscode-wpilib/resources/gradle/shared/.gitignore#L180