### PR TITLE
Fix robot.py file check - #110

### DIFF
--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -19,7 +19,7 @@ from . import pypackages, pyproject, roborio_utils, sshcontroller
 from .installer import PipInstallError, PythonMissingError, RobotpyInstaller
 from .installer import _ROBOTPY_PYTHON_VERSION_TUPLE as required_pyversion
 from .errors import Error
-from .utils import handle_cli_error, print_err, yesno, exists_case_sensative
+from .utils import handle_cli_error, print_err, yesno, exists_case_sensitive
 
 import logging
 
@@ -166,9 +166,9 @@ class Deploy:
         team: typing.Optional[int],
         no_resolve: bool,
     ):
-        if not exists_case_sensative(main_file):
+        if not exists_case_sensitive(main_file):
             print(
-                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensative",
+                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensitive",
                 file=sys.stderr,
             )
             return 1

--- a/robotpy_installer/cli_deploy_info.py
+++ b/robotpy_installer/cli_deploy_info.py
@@ -7,7 +7,7 @@ import typing
 
 from . import sshcontroller
 
-from .utils import handle_cli_error, exists_case_sensative
+from .utils import handle_cli_error, exists_case_sensitive
 from .utils import print_err
 
 
@@ -43,9 +43,9 @@ class DeployInfo:
         team: typing.Optional[int],
         no_resolve: bool,
     ):
-        if not exists_case_sensative(main_file):
+        if not exists_case_sensitive(main_file):
             print(
-                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensative",
+                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensitive",
                 file=sys.stderr,
             )
             return 1

--- a/robotpy_installer/cli_sync.py
+++ b/robotpy_installer/cli_sync.py
@@ -9,7 +9,7 @@ import tempfile
 
 from packaging.version import Version
 
-from .utils import handle_cli_error, yesno, exists_case_sensative
+from .utils import handle_cli_error, yesno, exists_case_sensitive
 
 
 from .installer import RobotpyInstaller
@@ -84,9 +84,9 @@ class Sync:
         user: bool,
         use_certifi: bool,
     ):
-        if not exists_case_sensative(main_file):
+        if not exists_case_sensitive(main_file):
             print(
-                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensative",
+                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensitive",
                 file=sys.stderr,
             )
             return 1

--- a/robotpy_installer/cli_undeploy.py
+++ b/robotpy_installer/cli_undeploy.py
@@ -7,7 +7,7 @@ import typing
 from os.path import abspath, dirname, join
 
 from . import sshcontroller
-from .utils import print_err, yesno, exists_case_sensative
+from .utils import print_err, yesno, exists_case_sensitive
 
 
 class Undeploy:
@@ -49,9 +49,9 @@ class Undeploy:
         no_resolve: bool,
         yes: bool,
     ):
-        if not exists_case_sensative(main_file):
+        if not exists_case_sensitive(main_file):
             print(
-                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensative",
+                f"ERROR: is this a robot project? {main_file} does not exist; The file name is case sensitive",
                 file=sys.stderr,
             )
             return 1

--- a/robotpy_installer/utils.py
+++ b/robotpy_installer/utils.py
@@ -194,9 +194,9 @@ def handle_cli_error(func):
     return wrapper
 
 
-def exists_case_sensative(path: pathlib.Path) -> bool:
+def exists_case_sensitive(path: pathlib.Path) -> bool:
     """
-    case sensative replacement for pathlib.Path.exists().
+    case sensitive replacement for pathlib.Path.exists().
     This only checks the file or dir at the end of the path exists and has correct case.
     This is required because Windows by default does not check case.
     In the case where the path ends in '..' and the directory exists then True is returned.


### PR DESCRIPTION
Issue #110. There is already a [check for the robot.py file in robotpy-cli ](https://github.com/robotpy/robotpy-cli/blob/c6b6838c44d6ca3c7f2e93492b2e153f9b1ff218/robotpy/main.py#L45)that should catch incorrect capitalization but doesn't. In my PR I fixed the issue in robotpy-installer but it may be better suited in robotpy-cli. 

This issue stems from the fact that Windows does not differentiate between files with different capitalization. So 'robot.py' and ‘Robot.py' are seen as the same file by Windows. The code uses the method pathlib.Path.exists() to check if the robot.py file exists. This method relies on the underlying operating system so it is permissive with case on Windows. This bug is also found in deploy-info, undeploy, and sync. I added the case sensitive check to those but only where the robot.py file is being checked. Theoretically this fix could also be used for other file checks but I am not sure if it is appropriate for all situations.