### PR TITLE
deploy: Refuse to run from a user's home directory

### DIFF
--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -166,6 +166,12 @@ class Deploy:
         team: typing.Optional[int],
         no_resolve: bool,
     ):
+        if main_file.parent == pathlib.Path.home():
+            print_err(
+                "ERROR: running 'deploy' from your home directory is not supported!"
+            )
+            return False
+
         # run the test suite before uploading
         if not skip_tests:
             test_args = [


### PR DESCRIPTION
- TBH there's lots of other ways to shoot yourself in the foot but this is an easy one
- Fixes #137