### PR TITLE
sshcontroller: Print collected output on command error

### DIFF
--- a/robotpy_installer/roborio_utils.py
+++ b/robotpy_installer/roborio_utils.py
@@ -91,15 +91,13 @@ def uninstall_cpp_java_admin(ssh: SshController):
 
 def get_rio_py_packages(ssh: SshController) -> typing.Dict[str, str]:
     # Use importlib.metadata instead of pip because it's way faster than pip
-    result = ssh.exec_cmd(
+    output = ssh.check_output(
         "/usr/local/bin/python3 -c "
         "'from importlib.metadata import distributions;"
         "import json; import sys; "
         "json.dump({dist.name: dist.version for dist in distributions()},sys.stdout)'",
-        get_output=True,
     )
-    assert result.stdout is not None
-    d = json.loads(result.stdout)
+    d = json.loads(output)
     # sometimes distributions.name or version is None
     return {k: v for k, v in d.items() if k and v}
 

--- a/robotpy_installer/sshcontroller.py
+++ b/robotpy_installer/sshcontroller.py
@@ -105,6 +105,11 @@ class SshController:
             retval = channel.recv_exit_status()
 
         if check and retval != 0:
+            if not print_output:
+                try:
+                    print(buffer.getvalue(), file=sys.stderr)
+                except UnicodeEncodeError:
+                    pass
             raise SshExecError(
                 "Command '%s' returned non-zero error status %s" % (cmd, retval),
                 retval,


### PR DESCRIPTION
On deploy, the Python script from `get_rio_py_packages` can sometimes fail, likely due to a `MemoryError` when deploying to a roboRIO 1.

https://github.com/robotpy/robotpy-installer/blob/44fdc6d757dcd7e6f65c7f537cc42bb1054dd8f7/robotpy_installer/roborio_utils.py#L92-L100

Print the error message from the robot in this scenario.