### PR TITLE
Handle VCS requirements via cached wheels on deploy

### DIFF
--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -534,7 +534,6 @@ class Deploy:
 
                 if not requirements_installed:
                     assert project is not None
-                    packages = project.get_install_list()
 
                     # Check if everything is in the cache before doing the install
                     cached = self._get_cached_packages(installer)
@@ -552,6 +551,11 @@ class Deploy:
                             "from the internet (or specify --no-install to not attempt installation).",
                         ]
                         raise Error("\n".join(errmsg))
+
+                    try:
+                        packages = project.get_deploy_list(cached)
+                    except KeyError as e:
+                        raise Error(str(e)) from e
 
                     if not no_uninstall:
                         logger.info(

--- a/robotpy_installer/cli_sync.py
+++ b/robotpy_installer/cli_sync.py
@@ -138,7 +138,9 @@ class Sync:
         except pyproject.NoRobotpyError:
             pass
 
-        packages = project.get_install_list()
+        install_reqs = project.get_install_reqs()
+        packages = list(map(str, install_reqs))
+        direct_url_packages = [str(req) for req in install_reqs if req.url is not None]
 
         logger.info("Robot project requirements:")
         for package in packages:
@@ -159,6 +161,16 @@ class Sync:
             packages=packages,
             find_links=find_links,
         )
+
+        if direct_url_packages:
+            logger.info("Building wheels for direct URL requirements")
+            installer.pip_wheel(
+                no_deps=True,
+                pre=False,
+                requirements=[],
+                packages=direct_url_packages,
+                find_links=find_links,
+            )
 
         #
         # Local requirement installation

--- a/robotpy_installer/installer.py
+++ b/robotpy_installer/installer.py
@@ -520,6 +520,64 @@ class RobotpyInstaller:
         if retval != 0:
             raise InstallerException("pip download failed")
 
+    def pip_wheel(
+        self,
+        no_deps: bool,
+        pre: bool,
+        requirements: typing.Sequence[pathlib.Path],
+        packages: typing.Sequence[str],
+        find_links: typing.Optional[pathlib.Path],
+    ):
+        """
+        Build wheel(s) for Python package(s) and store them in the cache.
+
+        This is primarily needed for direct URL/VCS requirements, because
+        ``pip download`` may only cache a source archive for those.
+        """
+
+        if not requirements and not packages:
+            raise InstallerException("You must give at least one requirement to wheel")
+
+        try:
+            import pip  # type: ignore
+        except ImportError:
+            raise InstallerException(
+                "ERROR: pip must be installed to build python wheels"
+            )
+
+        self.pip_cache.mkdir(parents=True, exist_ok=True)
+
+        pip_args = [
+            sys.executable,
+            "-m",
+            "pip",
+            "--disable-pip-version-check",
+            "wheel",
+            "-w",
+            str(self.pip_cache),
+        ]
+
+        if find_links:
+            pip_args += ["--find-links", str(find_links)]
+
+        self._extend_pip_args(
+            pip_args,
+            None,
+            False,
+            False,
+            no_deps,
+            pre,
+            requirements,
+        )
+
+        pip_args.extend(packages)
+
+        logger.debug("Using pip to build wheels: %s", pip_args)
+
+        retval = subprocess.call(pip_args)
+        if retval != 0:
+            raise InstallerException("pip wheel failed")
+
     def pip_install(
         self,
         force_reinstall: bool,

--- a/robotpy_installer/pypackages.py
+++ b/robotpy_installer/pypackages.py
@@ -109,6 +109,49 @@ def extra_resolver_local(req: Requirement, env: Env) -> typing.List[Requirement]
     return extra_reqs
 
 
+def get_cache_req_download_path(req: Requirement, packages: Packages) -> pathlib.Path:
+    """
+    Resolves a requirement to a downloaded file in the cache.
+
+    For direct URL requirements used by deploy, this allows us to install the
+    exact downloaded wheel instead of passing the original URL to pip on the
+    RoboRIO.
+    """
+
+    creqs = packages.get(canonicalize_name(req.name))
+    if creqs is None:
+        raise KeyError(f"{req} not downloaded in cache (did you do a sync?)")
+
+    req.specifier.prereleases = True
+
+    wheel_path = None
+    any_path = None
+
+    for creq in sorted(creqs, reverse=True):
+        if req.specifier and creq not in req.specifier:
+            continue
+
+        if not isinstance(creq, CacheVersion):
+            raise ValueError("internal error")
+
+        if any_path is None:
+            any_path = creq.file_path
+
+        if creq.file_path.suffix == ".whl":
+            wheel_path = creq.file_path
+            break
+
+    if wheel_path is not None:
+        return wheel_path
+
+    if any_path is not None:
+        raise KeyError(
+            f"{req} was downloaded to cache, but not as a wheel: {any_path.name}"
+        )
+
+    raise KeyError(f"{req} not downloaded in cache (did you do a sync?)")
+
+
 def make_cache_extra_resolver(packages: Packages) -> ExtraResolver:
     """
     :param packages: The list of packages in the cache as returned by
@@ -122,22 +165,7 @@ def make_cache_extra_resolver(packages: Packages) -> ExtraResolver:
         env = env.copy()
         env["extra"] = ",".join(req.extras)
 
-        # Find the requirement
-        creqs = packages.get(canonicalize_name(req.name))
-        if creqs is None:
-            raise KeyError(f"{req} not downloaded in cache (did you do a sync?)")
-
-        req.specifier.prereleases = True
-        for creq in sorted(creqs, reverse=True):
-            if req.specifier is None or creq in req.specifier:
-                break
-        else:
-            raise KeyError(f"{req} not downloaded in cache (did you do a sync?)")
-
-        if not isinstance(creq, CacheVersion):
-            raise ValueError("internal error")
-
-        m = metadata_from_wheel(creq.file_path)
+        m = metadata_from_wheel(get_cache_req_download_path(req, packages))
         if m.requires_dist:
             return evaluate_extras_markers(m.requires_dist, env, req.extras)
 

--- a/robotpy_installer/pyproject.py
+++ b/robotpy_installer/pyproject.py
@@ -114,6 +114,17 @@ class RobotPyProjectToml:
     def get_install_list(self) -> typing.List[str]:
         return list(map(str, self.get_install_reqs()))
 
+    def get_deploy_list(self, cached_packages: Packages) -> typing.List[str]:
+        deploy_list = []
+        for req in self.get_install_reqs():
+            if req.url is not None:
+                deploy_list.append(
+                    str(pypackages.get_cache_req_download_path(req, cached_packages))
+                )
+            else:
+                deploy_list.append(str(req))
+        return deploy_list
+
 
 def robotpy_installed_version() -> str:
     # this is a bit weird because this project doesn't depend on robotpy, it's

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,10 +1,12 @@
 import inspect
+import pathlib
 import typing
 
 from robotpy_installer import pyproject, pypackages
 from robotpy_installer.installer import _WPILIB_YEAR as YEAR
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 
 def load_project(content: str) -> pyproject.RobotPyProjectToml:
@@ -100,3 +102,48 @@ def test_env_marker():
         True,
         [],
     )
+
+
+def test_get_deploy_list_resolves_direct_url_to_wheel():
+    project = load_project(f"""
+        [tool.robotpy]
+        robotpy_version = "{YEAR}.1.1.2"
+        requires = [
+            "frc3484 @ git+https://github.com/FRC-Team3484/FRC3484_Lib_Python.git@main"
+        ]
+    """)
+
+    wheel = pathlib.Path("/tmp/frc3484-1.2.3-py3-none-any.whl")
+    cached = {
+        canonicalize_name("robotpy"): [
+            pypackages.CacheVersion(f"{YEAR}.1.1.2", pathlib.Path("/tmp/robotpy.whl"))
+        ],
+        canonicalize_name("frc3484"): [pypackages.CacheVersion("1.2.3", wheel)],
+    }
+
+    assert project.get_deploy_list(cached) == [f"robotpy=={YEAR}.1.1.2", str(wheel)]
+
+
+def test_get_deploy_list_requires_wheel_for_direct_url():
+    project = load_project(f"""
+        [tool.robotpy]
+        robotpy_version = "{YEAR}.1.1.2"
+        requires = [
+            "frc3484 @ git+https://github.com/FRC-Team3484/FRC3484_Lib_Python.git@main"
+        ]
+    """)
+
+    cached = {
+        canonicalize_name("robotpy"): [
+            pypackages.CacheVersion(f"{YEAR}.1.1.2", pathlib.Path("/tmp/robotpy.whl"))
+        ],
+        canonicalize_name("frc3484"): [
+            pypackages.CacheVersion("1.2.3", pathlib.Path("/tmp/frc3484-1.2.3.tar.gz"))
+        ],
+    }
+
+    try:
+        project.get_deploy_list(cached)
+        assert False
+    except KeyError as e:
+        assert "not as a wheel" in str(e)

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -118,7 +118,10 @@ def test_get_deploy_list_resolves_direct_url_to_wheel():
         canonicalize_name("robotpy"): [
             pypackages.CacheVersion(f"{YEAR}.1.1.2", pathlib.Path("/tmp/robotpy.whl"))
         ],
-        canonicalize_name("frc3484"): [pypackages.CacheVersion("1.2.3", wheel)],
+        canonicalize_name("frc3484"): [
+            pypackages.CacheVersion("1.2.3", pathlib.Path("/tmp/frc3484-1.2.3.zip")),
+            pypackages.CacheVersion("1.2.3", wheel),
+        ],
     }
 
     assert project.get_deploy_list(cached) == [f"robotpy=={YEAR}.1.1.2", str(wheel)]


### PR DESCRIPTION
May resolve https://www.chiefdelphi.com/t/unable-to-deploy-a-custom-python-library-with-robotpy/515734

This fix is generated by gpt-5.4 (via `pi.dev`), and it looks like generally the correct fix. Unfortunately I won't have time to test this on a real system anytime in the next week or so.

Please try it and let me know if this resolves your issue.