### PR TITLE
Implement --local flag for deploy command

### DIFF
--- a/robotpy_installer/cacheserver.py
+++ b/robotpy_installer/cacheserver.py
@@ -4,8 +4,6 @@ import threading
 from http.server import SimpleHTTPRequestHandler
 from typing import Dict
 
-from robotpy_installer.sshcontroller import SshController
-
 logger = logging.getLogger("cacheserver")
 
 
@@ -28,23 +26,24 @@ class HTTPHandler(SimpleHTTPRequestHandler):
 
 
 class CacheServer:
-    def __init__(self, ssh_controller: SshController, cache_root: pathlib.Path):
+    def __init__(self, ssh_controller, cache_root: pathlib.Path):
         self.controller = ssh_controller
         self.cache_root = cache_root
-
-        self.transport = self.controller.client.get_transport()
-        assert self.transport is not None
-        self.port = self.transport.request_port_forward("", 0)
-
         self.mapped_files: Dict[str, str] = {}
+        self._closed = threading.Event()
+        self.port = self.controller.cache_listen()
 
     def add_mapping(self, fname: str, local_file: str):
         self.mapped_files[fname] = local_file
 
     def start(self):
         t = threading.Thread(target=self._handle_requests)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
+
+    def close(self):
+        self._closed.set()
+        self.controller.cache_close()
 
     def process_request(self, request):
         client_address = request.getpeername()
@@ -56,18 +55,29 @@ class CacheServer:
                 server=None,
                 directory=self.cache_root,
             ).handle()
-        except OSError as e:
-            if str(e) == "File is closed":
+        except (OSError, ValueError) as e:
+            if str(e) in ("File is closed", "readline of closed file"):
                 return
+            raise
         finally:
             request.close()
 
     def _handle_requests(self):
-        request = self.transport.accept()
+        while not self._closed.is_set():
+            try:
+                request = self.controller.cache_accept()
+            except OSError:
+                if self._closed.is_set():
+                    return
+                raise
 
-        while request is not None:
+            if request is None:
+                return
+
+            if self._closed.is_set():
+                request.close()
+                return
+
             t = threading.Thread(target=self.process_request, args=[request])
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
-
-            request = self.transport.accept()

--- a/robotpy_installer/cacheserver.py
+++ b/robotpy_installer/cacheserver.py
@@ -4,6 +4,8 @@ import threading
 from http.server import SimpleHTTPRequestHandler
 from typing import Dict
 
+from robotpy_installer.sshcontroller import ControllerProtocol
+
 logger = logging.getLogger("cacheserver")
 
 
@@ -26,7 +28,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
 
 
 class CacheServer:
-    def __init__(self, ssh_controller, cache_root: pathlib.Path):
+    def __init__(self, ssh_controller: ControllerProtocol, cache_root: pathlib.Path):
         self.controller = ssh_controller
         self.cache_root = cache_root
         self.mapped_files: Dict[str, str] = {}

--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -18,7 +18,7 @@ from os.path import join, splitext
 from . import pypackages, pyproject, robot_utils, sshcontroller
 from .installer import PipInstallError, PythonMissingError, RobotpyInstaller
 from .installer import _ROBOTPY_PYTHON_VERSION_TUPLE as required_pyversion
-from .installer import _ROBOT_VENV_PYTHON
+from .installer import _ROBOT_VENV, _ROBOT_VENV_PYTHON
 from .errors import Error
 from .utils import handle_cli_error, print_err, yesno
 
@@ -27,6 +27,7 @@ import logging
 logger = logging.getLogger("deploy")
 
 _LOCAL_DEFAULT_CACHE_ROOT = pathlib.Path("/opt/blocks/cache")
+_NO_VERIFY_WITHOUT_WARNING = object()
 
 
 @contextlib.contextmanager
@@ -245,9 +246,10 @@ class Deploy:
                 logger.info("- %s", package)
 
             if no_verify:
-                logger.warning(
-                    "Not checking to see if they are installed on SystemCore"
-                )
+                if no_verify is not _NO_VERIFY_WITHOUT_WARNING:
+                    logger.warning(
+                        "Not checking to see if they are installed on SystemCore"
+                    )
             else:
                 requirements_met, desc = project.are_local_requirements_met()
                 if not requirements_met:
@@ -555,19 +557,13 @@ class Deploy:
                         pypackages.robot_env(),
                         pypackages.make_cache_extra_resolver(cached),
                     )
-                    # The user may have deleted something from the project
-                    # requirements so the only way to ensure the exact
-                    # environment is to first clear the environment.
-                    # - can't do a partial uninstall without completely
-                    #   resolving everything
-                    self._clear_pip_packages(installer)
 
                     try:
                         packages = project.get_deploy_list(cached)
                     except KeyError as e:
                         raise Error(str(e)) from e
 
-                    if not no_uninstall:
+                    if not no_uninstall and ssh.sftp_remote_file_exists(_ROBOT_VENV):
                         logger.info(
                             "Clearing existing packages on robot before install (specify --no-uninstall to not do this)"
                         )
@@ -750,14 +746,6 @@ class LocalDeploy(Deploy):
             help="Ignore SystemCore image version",
         )
 
-        parser.add_argument(
-            "-n",
-            "--no-verify",
-            action="store_true",
-            default=False,
-            help="If specified, do not verify that the robotpy version in pyproject.toml is installed locally",
-        )
-
         install_args = parser.add_mutually_exclusive_group()
 
         install_args.add_argument(
@@ -806,7 +794,6 @@ class LocalDeploy(Deploy):
         debug: bool,
         ignore_image_version: bool,
         no_install: bool,
-        no_verify: bool,
         no_uninstall: bool,
         force_install: bool,
         large: bool,
@@ -824,7 +811,7 @@ class LocalDeploy(Deploy):
             nc_ds=False,
             ignore_image_version=ignore_image_version,
             no_install=no_install,
-            no_verify=no_verify,
+            no_verify=_NO_VERIFY_WITHOUT_WARNING,
             no_uninstall=no_uninstall,
             force_install=force_install,
             large=large,

--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -727,3 +727,110 @@ class Deploy:
                     shutil.copy(fname, tmp_dir / prefix / filename)
 
         return upload_files
+
+
+class LocalDeploy(Deploy):
+    """
+    Uploads code to the current SystemCore without importing robot code locally or
+    running tests.
+    """
+
+    def __init__(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--debug",
+            action="store_true",
+            default=False,
+            help="If specified, runs the code in debug mode (which only currently enables verbose logging)",
+        )
+
+        parser.add_argument(
+            "--ignore-image-version",
+            action="store_true",
+            default=False,
+            help="Ignore SystemCore image version",
+        )
+
+        parser.add_argument(
+            "-n",
+            "--no-verify",
+            action="store_true",
+            default=False,
+            help="If specified, do not verify that the robotpy version in pyproject.toml is installed locally",
+        )
+
+        install_args = parser.add_mutually_exclusive_group()
+
+        install_args.add_argument(
+            "--no-install",
+            action="store_true",
+            default=False,
+            help="If specified, do not use pyproject.toml to install packages on the robot before deploy",
+        )
+
+        install_args.add_argument(
+            "--force-install",
+            action="store_true",
+            default=False,
+            help="Force installation of packages required by pyproject.toml",
+        )
+
+        parser.add_argument(
+            "--no-uninstall",
+            action="store_true",
+            default=False,
+            help="Do not uninstall packages from the SystemCore",
+        )
+
+        parser.add_argument(
+            "--large",
+            action="store_true",
+            default=False,
+            help="If specified, allow uploading large files (> 250k) to the SystemCore",
+        )
+
+        parser.add_argument(
+            "--cache-root",
+            type=pathlib.Path,
+            default=None,
+            help="Override RobotPy installer cache location; defaults to /opt/blocks/cache",
+        )
+
+        self._packages_in_cache: typing.Optional[pypackages.Packages] = None
+        self._robot_packages: typing.Optional[pypackages.Packages] = None
+
+    @handle_cli_error
+    def run(
+        self,
+        main_file: pathlib.Path,
+        project_path: pathlib.Path,
+        debug: bool,
+        ignore_image_version: bool,
+        no_install: bool,
+        no_verify: bool,
+        no_uninstall: bool,
+        force_install: bool,
+        large: bool,
+        cache_root: typing.Optional[pathlib.Path],
+    ):
+        return Deploy.run(
+            self,
+            main_file=main_file,
+            project_path=project_path,
+            robot_class=None,
+            builtin=False,
+            skip_tests=True,
+            debug=debug,
+            nc=False,
+            nc_ds=False,
+            ignore_image_version=ignore_image_version,
+            no_install=no_install,
+            no_verify=no_verify,
+            no_uninstall=no_uninstall,
+            force_install=force_install,
+            large=large,
+            robot=None,
+            team=None,
+            no_resolve=False,
+            local=True,
+            cache_root=cache_root,
+        )

--- a/robotpy_installer/cli_deploy.py
+++ b/robotpy_installer/cli_deploy.py
@@ -26,6 +26,8 @@ import logging
 
 logger = logging.getLogger("deploy")
 
+_LOCAL_DEFAULT_CACHE_ROOT = pathlib.Path("/opt/blocks/cache")
+
 
 @contextlib.contextmanager
 def wrap_ssh_error(msg: str):
@@ -136,6 +138,20 @@ class Deploy:
             "--team", default=None, type=int, help="Set team number to deploy robot for"
         )
 
+        robot_args.add_argument(
+            "--local",
+            action="store_true",
+            default=False,
+            help="Deploy to the current SystemCore without SSH",
+        )
+
+        parser.add_argument(
+            "--cache-root",
+            type=pathlib.Path,
+            default=None,
+            help="Override RobotPy installer cache location; defaults to /opt/blocks/cache with --local",
+        )
+
         parser.add_argument(
             "--no-resolve",
             action="store_true",
@@ -166,6 +182,8 @@ class Deploy:
         robot: typing.Optional[str],
         team: typing.Optional[int],
         no_resolve: bool,
+        local: bool,
+        cache_root: typing.Optional[pathlib.Path],
     ):
         if main_file.parent == pathlib.Path.home():
             print_err(
@@ -248,13 +266,21 @@ class Deploy:
                     )
                     raise Error(msg)
 
-        installer = RobotpyInstaller()
+        ssh: typing.Optional[sshcontroller.ControllerProtocol] = None
+        if local:
+            if cache_root is None:
+                cache_root = _LOCAL_DEFAULT_CACHE_ROOT
+            ssh = sshcontroller.LocalController()
+
+        installer = RobotpyInstaller(cache_root=cache_root)
 
         with installer.connect_to_robot(
             project_path=project_path,
             main_file=main_file,
             robot_or_team=robot or team,
             ignore_image_version=ignore_image_version,
+            no_resolve=no_resolve,
+            ssh=ssh,
         ) as ssh:
             self._ensure_requirements(
                 project,
@@ -350,7 +376,7 @@ class Deploy:
         return self._packages_in_cache
 
     def _get_robot_packages(
-        self, ssh: sshcontroller.SshController
+        self, ssh: sshcontroller.ControllerProtocol
     ) -> pypackages.Packages:
         if self._robot_packages is None:
             rio_packages = robot_utils.get_robot_py_packages(ssh)
@@ -366,7 +392,7 @@ class Deploy:
         self,
         project: typing.Optional[pyproject.RobotPyProjectToml],
         installer: RobotpyInstaller,
-        ssh: sshcontroller.SshController,
+        ssh: sshcontroller.ControllerProtocol,
         no_install: bool,
         force_install: bool,
         no_uninstall: bool,
@@ -563,7 +589,7 @@ class Deploy:
 
     def _do_deploy(
         self,
-        ssh: sshcontroller.SshController,
+        ssh: sshcontroller.ControllerProtocol,
         debug: bool,
         nc: bool,
         nc_ds: bool,
@@ -656,7 +682,7 @@ class Deploy:
 
         return True
 
-    def _start_nc(self, ssh: sshcontroller.SshController, nc_ds: bool):
+    def _start_nc(self, ssh: sshcontroller.ControllerProtocol, nc_ds: bool):
         from netconsole import run  # type: ignore
 
         nc_event = threading.Event()

--- a/robotpy_installer/cli_installer.py
+++ b/robotpy_installer/cli_installer.py
@@ -3,9 +3,10 @@ import pathlib
 import shutil
 import typing
 
-from . import pypackages, robot_utils
+from . import pypackages, robot_utils, sshcontroller
 from .utils import handle_cli_error
 
+from .cli_deploy import LocalDeploy
 from .installer import (
     InstallerException,
     RobotpyInstaller,
@@ -14,11 +15,19 @@ from .installer import (
 from .utils import yesno
 
 
-def _add_ssh_options(parser: argparse.ArgumentParser):
+def _add_ssh_options(parser: argparse.ArgumentParser, *, local: bool = False):
     parser.add_argument(
         "--robot",
         help="Specify the robot hostname or team number",
     )
+
+    if local:
+        parser.add_argument(
+            "--local",
+            action="store_true",
+            default=False,
+            help="Run command against the current SystemCore without SSH",
+        )
 
     parser.add_argument(
         "--ignore-image-version",
@@ -26,6 +35,18 @@ def _add_ssh_options(parser: argparse.ArgumentParser):
         default=False,
         help="Ignore SystemCore image version",
     )
+
+
+def _local_controller(local: bool) -> typing.Optional[sshcontroller.ControllerProtocol]:
+    if local:
+        return sshcontroller.LocalController()
+    return None
+
+
+def _robot_or_team(robot: typing.Optional[str], local: bool) -> typing.Optional[str]:
+    if local:
+        return None
+    return robot
 
 
 def _add_cache_root_option(parser: argparse.ArgumentParser):
@@ -39,9 +60,10 @@ def _add_cache_root_option(parser: argparse.ArgumentParser):
 
 class _BasicInstallerCmd:
     log_usage = True
+    allow_local = True
 
     def __init__(self, parser: argparse.ArgumentParser) -> None:
-        _add_ssh_options(parser)
+        _add_ssh_options(parser, local=self.allow_local)
 
     @handle_cli_error
     def run(
@@ -50,14 +72,16 @@ class _BasicInstallerCmd:
         main_file: pathlib.Path,
         ignore_image_version: bool,
         robot: typing.Optional[str],
+        local: bool = False,
     ):
         installer = RobotpyInstaller()
         with installer.connect_to_robot(
             project_path=project_path,
             main_file=main_file,
-            robot_or_team=robot,
+            robot_or_team=_robot_or_team(robot, local),
             ignore_image_version=ignore_image_version,
             log_usage=self.log_usage,
+            ssh=_local_controller(local),
         ):
             self.on_run(installer)
 
@@ -182,7 +206,7 @@ class InstallerUninstallRobotPy:
     """
 
     def __init__(self, parser: argparse.ArgumentParser) -> None:
-        _add_ssh_options(parser)
+        _add_ssh_options(parser, local=True)
         parser.add_argument("-y", "--yes", action="store_true", default=False)
 
     @handle_cli_error
@@ -193,6 +217,7 @@ class InstallerUninstallRobotPy:
         ignore_image_version: bool,
         robot: typing.Optional[str],
         yes: bool,
+        local: bool = False,
     ):
         if not yes and not yesno(
             "This will delete all python and user data! Continue?"
@@ -203,8 +228,9 @@ class InstallerUninstallRobotPy:
         with installer.connect_to_robot(
             project_path=project_path,
             main_file=main_file,
-            robot_or_team=robot,
+            robot_or_team=_robot_or_team(robot, local),
             ignore_image_version=ignore_image_version,
+            ssh=_local_controller(local),
         ):
             installer.uninstall_robotpy()
 
@@ -312,7 +338,7 @@ class InstallerInstall:
         )
 
         common_pip_options(parser)
-        _add_ssh_options(parser)
+        _add_ssh_options(parser, local=True)
 
     @handle_cli_error
     def run(
@@ -328,6 +354,7 @@ class InstallerInstall:
         requirements: typing.Tuple[pathlib.Path],
         packages: typing.Tuple[str],
         cache_root: typing.Optional[pathlib.Path],
+        local: bool = False,
     ):
         if len(requirements) == 0 and len(packages) == 0:
             raise InstallerException(
@@ -338,8 +365,9 @@ class InstallerInstall:
         with installer.connect_to_robot(
             project_path=project_path,
             main_file=main_file,
-            robot_or_team=robot,
+            robot_or_team=_robot_or_team(robot, local),
             ignore_image_version=ignore_image_version,
+            ssh=_local_controller(local),
         ):
             installer.pip_install(
                 force_reinstall, ignore_installed, no_deps, pre, requirements, packages
@@ -381,6 +409,7 @@ class InstallerList(_BasicInstallerCmd):
     """
 
     log_usage = False
+    allow_local = False
 
     def on_run(self, installer: RobotpyInstaller):
         installer.pip_list()
@@ -392,7 +421,7 @@ class InstallerUninstall:
     """
 
     def __init__(self, parser: argparse.ArgumentParser) -> None:
-        _add_ssh_options(parser)
+        _add_ssh_options(parser, local=True)
 
         parser.add_argument(
             "packages",
@@ -408,13 +437,15 @@ class InstallerUninstall:
         ignore_image_version: bool,
         robot: typing.Optional[str],
         packages: typing.List[str],
+        local: bool = False,
     ):
         installer = RobotpyInstaller()
         with installer.connect_to_robot(
             project_path=project_path,
             main_file=main_file,
-            robot_or_team=robot,
+            robot_or_team=_robot_or_team(robot, local),
             ignore_image_version=ignore_image_version,
+            ssh=_local_controller(local),
         ):
             installer.pip_uninstall(packages)
 
@@ -436,6 +467,7 @@ class Installer:
         ("install", InstallerInstall),
         ("install-python", InstallerInstallPython),
         ("list", InstallerList),
+        ("local-deploy", LocalDeploy),
         ("sshcmd", InstallerSshCommand),
         ("uninstall", InstallerUninstall),
         ("uninstall-python", InstallerUninstallPython),

--- a/robotpy_installer/cli_installer.py
+++ b/robotpy_installer/cli_installer.py
@@ -28,6 +28,15 @@ def _add_ssh_options(parser: argparse.ArgumentParser):
     )
 
 
+def _add_cache_root_option(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--cache-root",
+        type=pathlib.Path,
+        default=None,
+        help="Override RobotPy installer cache location",
+    )
+
+
 class _BasicInstallerCmd:
     log_usage = True
 
@@ -138,9 +147,14 @@ class InstallerDownloadPython:
             default=False,
             help="Use SSL certificates from certifi",
         )
+        _add_cache_root_option(parser)
 
-    def run(self, use_certifi: bool):
-        installer = RobotpyInstaller()
+    def run(
+        self,
+        use_certifi: bool,
+        cache_root: typing.Optional[pathlib.Path],
+    ):
+        installer = RobotpyInstaller(cache_root=cache_root)
         installer.download_python(use_certifi)
 
 
@@ -212,6 +226,8 @@ class InstallerUninstallJavaCpp(_BasicInstallerCmd):
 def common_pip_options(
     parser: argparse.ArgumentParser,
 ):
+    _add_cache_root_option(parser)
+
     parser.add_argument(
         "--no-deps",
         action="store_true",
@@ -266,8 +282,9 @@ class InstallerDownload:
         pre: bool,
         requirements: typing.Tuple[pathlib.Path],
         packages: typing.Tuple[str],
+        cache_root: typing.Optional[pathlib.Path],
     ):
-        installer = RobotpyInstaller()
+        installer = RobotpyInstaller(cache_root=cache_root)
         installer.pip_download(no_deps, pre, requirements, packages, find_links)
 
 
@@ -310,13 +327,14 @@ class InstallerInstall:
         pre: bool,
         requirements: typing.Tuple[pathlib.Path],
         packages: typing.Tuple[str],
+        cache_root: typing.Optional[pathlib.Path],
     ):
         if len(requirements) == 0 and len(packages) == 0:
             raise InstallerException(
                 "You must give at least one requirement to install"
             )
 
-        installer = RobotpyInstaller()
+        installer = RobotpyInstaller(cache_root=cache_root)
         with installer.connect_to_robot(
             project_path=project_path,
             main_file=main_file,

--- a/robotpy_installer/installer.py
+++ b/robotpy_installer/installer.py
@@ -362,7 +362,10 @@ class RobotpyInstaller:
         #
 
         with catch_ssh_error("checking for python venv"):
-            if not self.ssh.sftp_remote_file_exists(_ROBOT_VENV_PYTHON):
+            venv_exists = self.ssh.sftp_remote_file_exists(_ROBOT_VENV_PYTHON)
+
+        if not venv_exists:
+            with catch_ssh_error("creating new venv"):
                 self.ssh.check_output(f"{_ROBOT_PYTHON} -m venv {_ROBOT_VENV}")
 
         # Use pip stub to override the wheel platform on SystemCore

--- a/robotpy_installer/installer.py
+++ b/robotpy_installer/installer.py
@@ -19,7 +19,7 @@ from .version import version as __version__
 from . import robot_utils
 from .cacheserver import CacheServer
 from .errors import Error, SshExecError
-from .sshcontroller import SshController, ssh_from_cfg
+from .sshcontroller import ControllerProtocol, SshController, ssh_from_cfg
 from .utils import _urlretrieve
 
 _WPILIB_YEAR = "2027"
@@ -94,7 +94,7 @@ class RobotpyInstaller:
         self.pip_cache = self.cache_root / "pip_cache"
         self.pkg_cache = self.cache_root / "pkg_cache"
 
-        self._ssh: typing.Optional[SshController] = None
+        self._ssh: typing.Optional[ControllerProtocol] = None
         self._cache_server: typing.Optional[CacheServer] = None
 
         self._image_version_ok = False
@@ -114,8 +114,8 @@ class RobotpyInstaller:
         ignore_image_version: bool = False,
         log_usage: bool = True,
         no_resolve: bool = False,
-        ssh: typing.Optional[SshController] = None,
-    ) -> typing.Generator[SshController, None, None]:
+        ssh: typing.Optional[ControllerProtocol] = None,
+    ) -> typing.Generator[ControllerProtocol, None, None]:
         if ssh is None:
             ssh = ssh_from_cfg(
                 project_path,
@@ -157,7 +157,7 @@ class RobotpyInstaller:
         return self._cache_server
 
     @property
-    def ssh(self) -> SshController:
+    def ssh(self) -> ControllerProtocol:
         """Only access inside connect_to_robot context"""
         if self._ssh is None:
             raise RuntimeError("internal error")

--- a/robotpy_installer/installer.py
+++ b/robotpy_installer/installer.py
@@ -81,8 +81,16 @@ def catch_ssh_error(msg: str):
 
 
 class RobotpyInstaller:
-    def __init__(self, *, log_startup: bool = True):
-        self.cache_root = pathlib.Path.home() / "wpilib" / _WPILIB_YEAR / "robotpy"
+    def __init__(
+        self,
+        *,
+        log_startup: bool = True,
+        cache_root: typing.Optional[pathlib.Path] = None,
+    ):
+        if cache_root is None:
+            cache_root = pathlib.Path.home() / "wpilib" / _WPILIB_YEAR / "robotpy"
+
+        self.cache_root = cache_root
         self.pip_cache = self.cache_root / "pip_cache"
         self.pkg_cache = self.cache_root / "pkg_cache"
 

--- a/robotpy_installer/robot_utils.py
+++ b/robotpy_installer/robot_utils.py
@@ -2,7 +2,7 @@ import json
 import logging
 import typing
 
-from .sshcontroller import SshController
+from .sshcontroller import ControllerProtocol
 
 logger = logging.getLogger("robotpy.installer")
 
@@ -19,7 +19,7 @@ kill_robot_cmd = f"sudo systemctl stop robot"
 kill_script_content: typing.Optional[bytes] = None
 
 
-def uninstall_cpp_java(ssh: SshController):
+def uninstall_cpp_java(ssh: ControllerProtocol):
     """
     Frees up disk space by removing FRC C++/Java programs. This runs as lvuser or admin.
 
@@ -69,7 +69,7 @@ def uninstall_cpp_java(ssh: SshController):
 # )
 
 
-def get_robot_py_packages(ssh: SshController) -> typing.Dict[str, str]:
+def get_robot_py_packages(ssh: ControllerProtocol) -> typing.Dict[str, str]:
     if not ssh.sftp_remote_file_exists("/home/systemcore/venv/bin/python3"):
         return {}
 

--- a/robotpy_installer/sshcontroller.py
+++ b/robotpy_installer/sshcontroller.py
@@ -1,7 +1,10 @@
+import getpass
 import io
 import logging
 import re
 import os
+import shutil
+import subprocess
 from os.path import exists, join, expanduser, split as splitpath
 from pathlib import Path, PurePath, PurePosixPath
 import shlex
@@ -33,6 +36,8 @@ class SshExecResult(typing.NamedTuple):
 
 
 class SshController:
+    is_local = False
+
     """
     Use this to execute commands on a roboRIO in a cross platform manner
 
@@ -221,6 +226,173 @@ class SshController:
             return False
         finally:
             sftp.close()
+
+    def cache_listen(self) -> int:
+        transport = self.client.get_transport()
+        assert transport is not None
+        return transport.request_port_forward("", 0)
+
+    def cache_accept(self):
+        transport = self.client.get_transport()
+        assert transport is not None
+        return transport.accept()
+
+    def cache_close(self):
+        pass
+
+
+_LOCAL_ENV_ALLOWLIST = frozenset(
+    {
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "LANG",
+        "LC_ALL",
+    }
+)
+_LOCAL_ENV_PATH = "/bin:/sbin:/usr/bin:/usr/sbin"
+
+
+class LocalController:
+    """
+    Executes installer operations on the current machine using the same API
+    surface as SshController.
+    """
+
+    is_local = True
+
+    def __init__(self):
+        self.username = getpass.getuser()
+        self.password = ""
+        self.hostname = "localhost"
+        self._cache_socket: typing.Optional[socket.socket] = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def exec_cmd(
+        self,
+        cmd: str,
+        *,
+        check: bool = False,
+        get_output: bool = False,
+        print_output: bool = False,
+        stdin: typing.Optional[bytes] = None,
+    ) -> SshExecResult:
+        logger.debug(
+            "Executing local '%s' check=%s has_stdin=%s", cmd, check, bool(stdin)
+        )
+
+        env = {k: v for k, v in os.environ.items() if k in _LOCAL_ENV_ALLOWLIST}
+        env["PATH"] = _LOCAL_ENV_PATH
+
+        proc = subprocess.run(
+            cmd,
+            shell=True,
+            input=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+
+        stdout = proc.stdout.decode(errors="backslashreplace")
+        if print_output:
+            print(stdout, end="")
+
+        if check and proc.returncode != 0:
+            raise SshExecError(
+                "Command '%s' returned non-zero error status %s"
+                % (cmd, proc.returncode),
+                proc.returncode,
+            )
+
+        return SshExecResult(proc.returncode, stdout if get_output else None)
+
+    def exec_bash(
+        self,
+        /,
+        *commands: str,
+        bash_opts: str = "e",
+        check: bool = False,
+        get_output: bool = False,
+        print_output: bool = False,
+    ) -> SshExecResult:
+        parts = ["/bin/bash"]
+        if bash_opts:
+            parts.append(f"-{bash_opts}")
+        parts.append("-c")
+        parts.append(";".join(c for c in commands))
+        cmd = shlex.join(parts)
+        return self.exec_cmd(
+            cmd, check=check, get_output=get_output, print_output=print_output
+        )
+
+    def check_output(self, cmd: str, *, print_output: bool = False) -> str:
+        result = self.exec_cmd(
+            cmd,
+            check=True,
+            get_output=True,
+            print_output=print_output,
+        )
+        assert result.stdout is not None
+        return result.stdout
+
+    def sftp(self, local_path, remote_path, mkdir=True):
+        local_path = Path(local_path)
+        remote_path = Path(remote_path)
+        destination = remote_path / local_path.name
+
+        if mkdir:
+            destination.mkdir(parents=True, exist_ok=True)
+
+        for root, dirs, files in os.walk(local_path):
+            root_path = Path(root)
+            relative_root = root_path.relative_to(local_path)
+            destination_root = destination / relative_root
+            destination_root.mkdir(parents=True, exist_ok=True)
+
+            for fname in files:
+                local_fname = root_path / fname
+                remote_fname = destination_root / fname
+                print(local_fname.relative_to(local_path), "->", remote_fname)
+                shutil.copy2(local_fname, remote_fname)
+
+    def sftp_fp(self, fp, remote_path):
+        remote_path = Path(remote_path)
+        remote_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(remote_path, "wb") as out:
+            shutil.copyfileobj(fp, out)
+
+    def sftp_remote_file_exists(self, remote_path) -> bool:
+        return Path(remote_path).exists()
+
+    def cache_listen(self) -> int:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen()
+        self._cache_socket = sock
+        return sock.getsockname()[1]
+
+    def cache_accept(self):
+        assert self._cache_socket is not None
+        conn, _ = self._cache_socket.accept()
+        return conn
+
+    def cache_close(self):
+        sock = self._cache_socket
+        if sock is not None:
+            self._cache_socket = None
+            try:
+                with socket.create_connection(sock.getsockname(), timeout=0.1):
+                    pass
+            except OSError:
+                pass
+            sock.close()
 
 
 def ssh_from_cfg(

--- a/robotpy_installer/sshcontroller.py
+++ b/robotpy_installer/sshcontroller.py
@@ -35,6 +35,51 @@ class SshExecResult(typing.NamedTuple):
     stdout: typing.Optional[str]
 
 
+class ControllerProtocol(typing.Protocol):
+    username: str
+    password: str
+    hostname: str
+    is_local: bool
+
+    def __enter__(self) -> typing.Self: ...
+
+    def __exit__(self, *args): ...
+
+    def exec_cmd(
+        self,
+        cmd: str,
+        *,
+        check: bool = False,
+        get_output: bool = False,
+        print_output: bool = False,
+        stdin: typing.Optional[bytes] = None,
+    ) -> SshExecResult: ...
+
+    def exec_bash(
+        self,
+        /,
+        *commands: str,
+        bash_opts: str = "e",
+        check: bool = False,
+        get_output: bool = False,
+        print_output: bool = False,
+    ) -> SshExecResult: ...
+
+    def check_output(self, cmd: str, *, print_output: bool = False) -> str: ...
+
+    def sftp(self, local_path, remote_path, mkdir=True): ...
+
+    def sftp_fp(self, fp, remote_path): ...
+
+    def sftp_remote_file_exists(self, remote_path) -> bool: ...
+
+    def cache_listen(self) -> int: ...
+
+    def cache_accept(self): ...
+
+    def cache_close(self): ...
+
+
 class SshController:
     is_local = False
 

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -1,0 +1,110 @@
+import argparse
+import pathlib
+from unittest.mock import MagicMock, patch
+
+from robotpy_installer.cli_installer import (
+    InstallerDownload,
+    InstallerDownloadPython,
+    InstallerInstall,
+)
+
+
+def test_download_python_parser_accepts_cache_root(tmp_path):
+    parser = argparse.ArgumentParser()
+    InstallerDownloadPython(parser)
+
+    args = parser.parse_args(["--cache-root", str(tmp_path / "cache")])
+
+    assert args.cache_root == tmp_path / "cache"
+
+
+def test_download_python_uses_requested_cache_root(tmp_path):
+    cache_root = tmp_path / "cache"
+    cmd = InstallerDownloadPython(argparse.ArgumentParser())
+    fake_installer = MagicMock()
+
+    with patch(
+        "robotpy_installer.cli_installer.RobotpyInstaller", return_value=fake_installer
+    ) as installer_cls:
+        cmd.run(use_certifi=False, cache_root=cache_root)
+
+    installer_cls.assert_called_once_with(cache_root=cache_root)
+    fake_installer.download_python.assert_called_once_with(False)
+
+
+def test_download_parser_accepts_cache_root(tmp_path):
+    parser = argparse.ArgumentParser()
+    InstallerDownload(parser)
+
+    args = parser.parse_args(["--cache-root", str(tmp_path / "cache"), "robotpy"])
+
+    assert args.cache_root == tmp_path / "cache"
+    assert args.packages == ["robotpy"]
+
+
+def test_download_uses_requested_cache_root(tmp_path):
+    cache_root = tmp_path / "cache"
+    cmd = InstallerDownload(argparse.ArgumentParser())
+    fake_installer = MagicMock()
+    requirements = (tmp_path / "requirements.txt",)
+    packages = ("robotpy",)
+    find_links = tmp_path / "links"
+
+    with patch(
+        "robotpy_installer.cli_installer.RobotpyInstaller", return_value=fake_installer
+    ) as installer_cls:
+        cmd.run(
+            find_links=find_links,
+            no_deps=True,
+            pre=False,
+            requirements=requirements,
+            packages=packages,
+            cache_root=cache_root,
+        )
+
+    installer_cls.assert_called_once_with(cache_root=cache_root)
+    fake_installer.pip_download.assert_called_once_with(
+        True, False, requirements, packages, find_links
+    )
+
+
+def test_install_parser_accepts_cache_root(tmp_path):
+    parser = argparse.ArgumentParser()
+    InstallerInstall(parser)
+
+    args = parser.parse_args(["--cache-root", str(tmp_path / "cache"), "robotpy"])
+
+    assert args.cache_root == tmp_path / "cache"
+    assert args.packages == ["robotpy"]
+
+
+def test_install_uses_requested_cache_root(tmp_path):
+    cache_root = tmp_path / "cache"
+    cmd = InstallerInstall(argparse.ArgumentParser())
+    fake_installer = MagicMock()
+    fake_context = fake_installer.connect_to_robot.return_value
+    fake_context.__enter__.return_value = None
+    fake_context.__exit__.return_value = None
+
+    with patch(
+        "robotpy_installer.cli_installer.RobotpyInstaller", return_value=fake_installer
+    ) as installer_cls:
+        cmd.run(
+            project_path=tmp_path,
+            main_file=tmp_path / "robot.py",
+            ignore_image_version=False,
+            robot=None,
+            force_reinstall=False,
+            ignore_installed=False,
+            no_deps=True,
+            pre=False,
+            requirements=(),
+            packages=("robotpy",),
+            cache_root=cache_root,
+        )
+
+    installer_cls.assert_called_once_with(cache_root=cache_root)
+    fake_installer.connect_to_robot.assert_called_once()
+    fake_installer.pip_install.assert_called_once_with(
+        False, False, True, False, (), ("robotpy",)
+    )

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -6,7 +6,13 @@ from robotpy_installer.cli_installer import (
     InstallerDownload,
     InstallerDownloadPython,
     InstallerInstall,
+    InstallerInstallPython,
+    InstallerUninstall,
+    InstallerUninstallJavaCpp,
+    InstallerUninstallPython,
+    InstallerUninstallRobotPy,
 )
+from robotpy_installer.sshcontroller import LocalController
 
 
 def test_download_python_parser_accepts_cache_root(tmp_path):
@@ -78,6 +84,25 @@ def test_install_parser_accepts_cache_root(tmp_path):
     assert args.packages == ["robotpy"]
 
 
+def test_install_uninstall_parsers_accept_local():
+    command_classes = [
+        InstallerInstall,
+        InstallerInstallPython,
+        InstallerUninstall,
+        InstallerUninstallJavaCpp,
+        InstallerUninstallPython,
+        InstallerUninstallRobotPy,
+    ]
+
+    for command_cls in command_classes:
+        parser = argparse.ArgumentParser()
+        command_cls(parser)
+
+        args = parser.parse_args(["--local"])
+
+        assert args.local is True
+
+
 def test_install_uses_requested_cache_root(tmp_path):
     cache_root = tmp_path / "cache"
     cmd = InstallerInstall(argparse.ArgumentParser())
@@ -108,3 +133,135 @@ def test_install_uses_requested_cache_root(tmp_path):
     fake_installer.pip_install.assert_called_once_with(
         False, False, True, False, (), ("robotpy",)
     )
+
+
+def _fake_connected_installer():
+    fake_installer = MagicMock()
+    fake_context = fake_installer.connect_to_robot.return_value
+    fake_context.__enter__.return_value = None
+    fake_context.__exit__.return_value = None
+    return fake_installer
+
+
+def _assert_local_connection(fake_installer):
+    fake_installer.connect_to_robot.assert_called_once()
+    kwargs = fake_installer.connect_to_robot.call_args.kwargs
+    assert kwargs["robot_or_team"] is None
+    assert isinstance(kwargs["ssh"], LocalController)
+
+
+def test_install_local_uses_local_controller(tmp_path):
+    cmd = InstallerInstall(argparse.ArgumentParser())
+    fake_installer = _fake_connected_installer()
+
+    with patch(
+        "robotpy_installer.cli_installer.RobotpyInstaller", return_value=fake_installer
+    ):
+        cmd.run(
+            project_path=tmp_path,
+            main_file=tmp_path / "robot.py",
+            ignore_image_version=False,
+            robot="10.0.0.2",
+            local=True,
+            force_reinstall=False,
+            ignore_installed=False,
+            no_deps=True,
+            pre=False,
+            requirements=(),
+            packages=("robotpy",),
+            cache_root=None,
+        )
+
+    _assert_local_connection(fake_installer)
+    fake_installer.pip_install.assert_called_once_with(
+        False, False, True, False, (), ("robotpy",)
+    )
+
+
+def test_basic_install_uninstall_local_uses_local_controller(tmp_path):
+    for command_cls, method_name in [
+        (InstallerInstallPython, "install_python"),
+        (InstallerUninstallPython, "uninstall_python"),
+    ]:
+        cmd = command_cls(argparse.ArgumentParser())
+        fake_installer = _fake_connected_installer()
+
+        with patch(
+            "robotpy_installer.cli_installer.RobotpyInstaller",
+            return_value=fake_installer,
+        ):
+            cmd.run(
+                project_path=tmp_path,
+                main_file=tmp_path / "robot.py",
+                ignore_image_version=False,
+                robot="10.0.0.2",
+                local=True,
+            )
+
+        _assert_local_connection(fake_installer)
+        getattr(fake_installer, method_name).assert_called_once_with()
+
+
+def test_uninstall_robotpy_local_uses_local_controller(tmp_path):
+    cmd = InstallerUninstallRobotPy(argparse.ArgumentParser())
+    fake_installer = _fake_connected_installer()
+
+    with patch(
+        "robotpy_installer.cli_installer.RobotpyInstaller", return_value=fake_installer
+    ):
+        cmd.run(
+            project_path=tmp_path,
+            main_file=tmp_path / "robot.py",
+            ignore_image_version=False,
+            robot="10.0.0.2",
+            local=True,
+            yes=True,
+        )
+
+    _assert_local_connection(fake_installer)
+    fake_installer.uninstall_robotpy.assert_called_once_with()
+
+
+def test_uninstall_package_local_uses_local_controller(tmp_path):
+    cmd = InstallerUninstall(argparse.ArgumentParser())
+    fake_installer = _fake_connected_installer()
+
+    with patch(
+        "robotpy_installer.cli_installer.RobotpyInstaller", return_value=fake_installer
+    ):
+        cmd.run(
+            project_path=tmp_path,
+            main_file=tmp_path / "robot.py",
+            ignore_image_version=False,
+            robot="10.0.0.2",
+            local=True,
+            packages=["robotpy"],
+        )
+
+    _assert_local_connection(fake_installer)
+    fake_installer.pip_uninstall.assert_called_once_with(["robotpy"])
+
+
+def test_uninstall_java_cpp_local_uses_local_controller(tmp_path):
+    cmd = InstallerUninstallJavaCpp(argparse.ArgumentParser())
+    fake_installer = _fake_connected_installer()
+
+    with (
+        patch(
+            "robotpy_installer.cli_installer.RobotpyInstaller",
+            return_value=fake_installer,
+        ),
+        patch(
+            "robotpy_installer.cli_installer.robot_utils.uninstall_cpp_java"
+        ) as uninstall_cpp_java,
+    ):
+        cmd.run(
+            project_path=tmp_path,
+            main_file=tmp_path / "robot.py",
+            ignore_image_version=False,
+            robot="10.0.0.2",
+            local=True,
+        )
+
+    _assert_local_connection(fake_installer)
+    uninstall_cpp_java.assert_called_once_with(fake_installer.ssh)

--- a/tests/test_local_deploy.py
+++ b/tests/test_local_deploy.py
@@ -107,3 +107,119 @@ def test_cache_server_serves_local_controller_files(tmp_path):
         assert fp.read() == b"cached"
 
     server.close()
+
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+from robotpy_installer.cli_deploy import Deploy
+
+
+def _make_deploy_parser():
+    parser = argparse.ArgumentParser()
+    Deploy(parser)
+    return parser
+
+
+def test_deploy_parser_accepts_local_and_cache_root(tmp_path):
+    parser = _make_deploy_parser()
+
+    args = parser.parse_args(["--local", "--cache-root", str(tmp_path / "cache")])
+
+    assert args.local is True
+    assert args.cache_root == tmp_path / "cache"
+
+
+def test_deploy_local_uses_default_blocks_cache(tmp_path):
+    deploy = Deploy(argparse.ArgumentParser())
+    main_file = tmp_path / "robot.py"
+    main_file.write_text("print('robot')")
+
+    fake_installer = MagicMock()
+    fake_installer.connect_to_robot.return_value.__enter__.return_value = (
+        LocalController()
+    )
+    fake_installer.connect_to_robot.return_value.__exit__.return_value = None
+
+    with patch(
+        "robotpy_installer.cli_deploy.RobotpyInstaller", return_value=fake_installer
+    ) as installer_cls:
+        with (
+            patch.object(deploy, "_check_large_files", return_value=True),
+            patch.object(deploy, "_ensure_requirements"),
+            patch.object(deploy, "_do_deploy", return_value=True),
+        ):
+            result = deploy.run(
+                main_file=main_file,
+                project_path=tmp_path,
+                robot_class=object,
+                builtin=False,
+                skip_tests=True,
+                debug=False,
+                nc=False,
+                nc_ds=False,
+                ignore_image_version=False,
+                no_install=True,
+                no_verify=False,
+                no_uninstall=False,
+                force_install=False,
+                large=False,
+                robot=None,
+                team=None,
+                no_resolve=False,
+                local=True,
+                cache_root=None,
+            )
+
+    assert result == 0
+    installer_cls.assert_called_once_with(cache_root=pathlib.Path("/opt/blocks/cache"))
+    fake_installer.connect_to_robot.assert_called_once()
+    assert isinstance(
+        fake_installer.connect_to_robot.call_args.kwargs["ssh"], LocalController
+    )
+
+
+def test_deploy_local_uses_requested_cache_root(tmp_path):
+    deploy = Deploy(argparse.ArgumentParser())
+    main_file = tmp_path / "robot.py"
+    main_file.write_text("print('robot')")
+    cache_root = tmp_path / "cache"
+
+    fake_installer = MagicMock()
+    fake_installer.connect_to_robot.return_value.__enter__.return_value = (
+        LocalController()
+    )
+    fake_installer.connect_to_robot.return_value.__exit__.return_value = None
+
+    with patch(
+        "robotpy_installer.cli_deploy.RobotpyInstaller", return_value=fake_installer
+    ) as installer_cls:
+        with (
+            patch.object(deploy, "_check_large_files", return_value=True),
+            patch.object(deploy, "_ensure_requirements"),
+            patch.object(deploy, "_do_deploy", return_value=True),
+        ):
+            result = deploy.run(
+                main_file=main_file,
+                project_path=tmp_path,
+                robot_class=object,
+                builtin=False,
+                skip_tests=True,
+                debug=False,
+                nc=False,
+                nc_ds=False,
+                ignore_image_version=False,
+                no_install=True,
+                no_verify=False,
+                no_uninstall=False,
+                force_install=False,
+                large=False,
+                robot=None,
+                team=None,
+                no_resolve=False,
+                local=True,
+                cache_root=cache_root,
+            )
+
+    assert result == 0
+    installer_cls.assert_called_once_with(cache_root=cache_root)

--- a/tests/test_local_deploy.py
+++ b/tests/test_local_deploy.py
@@ -112,7 +112,8 @@ def test_cache_server_serves_local_controller_files(tmp_path):
 import argparse
 from unittest.mock import MagicMock, patch
 
-from robotpy_installer.cli_deploy import Deploy
+from robotpy_installer.cli_deploy import Deploy, LocalDeploy
+from robotpy_installer.cli_installer import Installer
 
 
 def _make_deploy_parser():
@@ -128,6 +129,70 @@ def test_deploy_parser_accepts_local_and_cache_root(tmp_path):
 
     assert args.local is True
     assert args.cache_root == tmp_path / "cache"
+
+
+def test_local_deploy_parser_has_no_robot_or_test_options(tmp_path):
+    parser = argparse.ArgumentParser()
+    LocalDeploy(parser)
+
+    args = parser.parse_args(["--cache-root", str(tmp_path / "cache")])
+
+    assert args.cache_root == tmp_path / "cache"
+    assert not hasattr(args, "local")
+    assert not hasattr(args, "robot")
+    assert not hasattr(args, "team")
+    assert not hasattr(args, "skip_tests")
+    assert not hasattr(args, "builtin")
+    assert not hasattr(args, "nc")
+    assert not hasattr(args, "nc_ds")
+    assert not hasattr(args, "no_resolve")
+
+
+def test_local_deploy_installer_subcommand_is_registered():
+    assert ("local-deploy", LocalDeploy) in Installer.subcommands
+
+
+def test_local_deploy_runs_local_without_tests_or_robot_class(tmp_path):
+    deploy = LocalDeploy(argparse.ArgumentParser())
+    main_file = tmp_path / "robot.py"
+    main_file.write_text("print('robot')")
+
+    fake_installer = MagicMock()
+    fake_installer.connect_to_robot.return_value.__enter__.return_value = (
+        LocalController()
+    )
+    fake_installer.connect_to_robot.return_value.__exit__.return_value = None
+
+    with patch(
+        "robotpy_installer.cli_deploy.RobotpyInstaller", return_value=fake_installer
+    ) as installer_cls:
+        with (
+            patch.object(deploy, "_check_large_files", return_value=True),
+            patch.object(deploy, "_ensure_requirements"),
+            patch.object(deploy, "_do_deploy", return_value=True),
+            patch("robotpy_installer.cli_deploy.subprocess.run") as subprocess_run,
+        ):
+            result = deploy.run(
+                main_file=main_file,
+                project_path=tmp_path,
+                debug=False,
+                ignore_image_version=False,
+                no_install=True,
+                no_verify=False,
+                no_uninstall=False,
+                force_install=False,
+                large=False,
+                cache_root=None,
+            )
+
+    assert result == 0
+    subprocess_run.assert_not_called()
+    installer_cls.assert_called_once_with(cache_root=pathlib.Path("/opt/blocks/cache"))
+    fake_installer.connect_to_robot.assert_called_once()
+    assert fake_installer.connect_to_robot.call_args.kwargs["robot_or_team"] is None
+    assert isinstance(
+        fake_installer.connect_to_robot.call_args.kwargs["ssh"], LocalController
+    )
 
 
 def test_deploy_local_uses_default_blocks_cache(tmp_path):

--- a/tests/test_local_deploy.py
+++ b/tests/test_local_deploy.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 from robotpy_installer.installer import RobotpyInstaller, _WPILIB_YEAR
@@ -22,3 +23,87 @@ def test_installer_cache_root_can_be_overridden(tmp_path):
     assert installer.cache_root == cache_root
     assert installer.pip_cache == cache_root / "pip_cache"
     assert installer.pkg_cache == cache_root / "pkg_cache"
+
+
+import io
+
+from robotpy_installer.errors import SshExecError
+from robotpy_installer.sshcontroller import LocalController
+
+
+def test_local_controller_exec_cmd_captures_output():
+    with LocalController() as controller:
+        result = controller.exec_cmd("printf hello", check=True, get_output=True)
+
+    assert result.returncode == 0
+    assert result.stdout == "hello"
+
+
+def test_local_controller_exec_cmd_raises_on_check_failure():
+    with LocalController() as controller:
+        try:
+            controller.exec_cmd("exit 7", check=True)
+        except SshExecError as e:
+            assert e.retval == 7
+        else:
+            raise AssertionError("expected SshExecError")
+
+
+def test_local_controller_exec_cmd_uses_minimal_environment(monkeypatch):
+    monkeypatch.setenv("ROBOTPY_SHOULD_NOT_LEAK", "bad")
+    monkeypatch.setenv("HOME", "/tmp/robotpy-home")
+    monkeypatch.setenv("PATH", "/tmp/should-not-leak")
+
+    with LocalController() as controller:
+        result = controller.exec_cmd(
+            'printf \'%s:%s:%s\' "$HOME" "$PATH" "$ROBOTPY_SHOULD_NOT_LEAK"',
+            check=True,
+            get_output=True,
+        )
+
+    assert result.stdout == "/tmp/robotpy-home:/bin:/sbin:/usr/bin:/usr/sbin:"
+
+
+def test_local_controller_sftp_copies_directory(tmp_path):
+    source_root = tmp_path / "source"
+    source_child = source_root / "py_new"
+    source_child.mkdir(parents=True)
+    (source_child / "robot.py").write_text("print('robot')")
+    destination = tmp_path / "dest"
+
+    with LocalController() as controller:
+        controller.sftp(source_child, destination, mkdir=True)
+
+    assert (destination / "py_new" / "robot.py").read_text() == "print('robot')"
+
+
+def test_local_controller_sftp_fp_writes_file(tmp_path):
+    destination = tmp_path / "nested" / "file.txt"
+
+    with LocalController() as controller:
+        controller.sftp_fp(io.BytesIO(b"data"), str(destination))
+
+    assert destination.read_bytes() == b"data"
+    assert controller.sftp_remote_file_exists(str(destination))
+
+
+import urllib.request
+
+from robotpy_installer.cacheserver import CacheServer
+
+
+def test_cache_server_serves_local_controller_files(tmp_path):
+    cache_root = tmp_path / "cache"
+    pip_cache = cache_root / "pip_cache"
+    pip_cache.mkdir(parents=True)
+    (pip_cache / "example.txt").write_text("cached")
+
+    server = CacheServer(LocalController(), cache_root)
+    server.start()
+
+    with urllib.request.urlopen(
+        f"http://localhost:{server.port}/pip_cache/example.txt"
+    ) as fp:
+        assert fp.read() == b"cached"
+
+    server.close()

--- a/tests/test_local_deploy.py
+++ b/tests/test_local_deploy.py
@@ -1,6 +1,9 @@
 import inspect
 import os
 import pathlib
+import sys
+
+import pytest
 
 from robotpy_installer.installer import RobotpyInstaller, _WPILIB_YEAR
 
@@ -31,7 +34,12 @@ import io
 from robotpy_installer.errors import SshExecError
 from robotpy_installer.sshcontroller import LocalController
 
+skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32", reason="LocalController executes POSIX SystemCore commands"
+)
 
+
+@skip_on_windows
 def test_local_controller_exec_cmd_captures_output():
     with LocalController() as controller:
         result = controller.exec_cmd("printf hello", check=True, get_output=True)
@@ -40,6 +48,7 @@ def test_local_controller_exec_cmd_captures_output():
     assert result.stdout == "hello"
 
 
+@skip_on_windows
 def test_local_controller_exec_cmd_raises_on_check_failure():
     with LocalController() as controller:
         try:
@@ -50,6 +59,7 @@ def test_local_controller_exec_cmd_raises_on_check_failure():
             raise AssertionError("expected SshExecError")
 
 
+@skip_on_windows
 def test_local_controller_exec_cmd_uses_minimal_environment(monkeypatch):
     monkeypatch.setenv("ROBOTPY_SHOULD_NOT_LEAK", "bad")
     monkeypatch.setenv("HOME", "/tmp/robotpy-home")
@@ -65,6 +75,7 @@ def test_local_controller_exec_cmd_uses_minimal_environment(monkeypatch):
     assert result.stdout == "/tmp/robotpy-home:/bin:/sbin:/usr/bin:/usr/sbin:"
 
 
+@skip_on_windows
 def test_local_controller_sftp_copies_directory(tmp_path):
     source_root = tmp_path / "source"
     source_child = source_root / "py_new"
@@ -78,6 +89,7 @@ def test_local_controller_sftp_copies_directory(tmp_path):
     assert (destination / "py_new" / "robot.py").read_text() == "print('robot')"
 
 
+@skip_on_windows
 def test_local_controller_sftp_fp_writes_file(tmp_path):
     destination = tmp_path / "nested" / "file.txt"
 

--- a/tests/test_local_deploy.py
+++ b/tests/test_local_deploy.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import pathlib
 
@@ -112,8 +113,9 @@ def test_cache_server_serves_local_controller_files(tmp_path):
 import argparse
 from unittest.mock import MagicMock, patch
 
-from robotpy_installer.cli_deploy import Deploy, LocalDeploy
+from robotpy_installer.cli_deploy import Deploy, LocalDeploy, required_pyversion
 from robotpy_installer.cli_installer import Installer
+from robotpy_installer.installer import _ROBOT_VENV
 
 
 def _make_deploy_parser():
@@ -146,10 +148,55 @@ def test_local_deploy_parser_has_no_robot_or_test_options(tmp_path):
     assert not hasattr(args, "nc")
     assert not hasattr(args, "nc_ds")
     assert not hasattr(args, "no_resolve")
+    assert not hasattr(args, "no_verify")
 
 
 def test_local_deploy_installer_subcommand_is_registered():
     assert ("local-deploy", LocalDeploy) in Installer.subcommands
+
+
+def test_deploy_run_has_no_suppress_no_verify_warning_argument():
+    assert "suppress_no_verify_warning" not in inspect.signature(Deploy.run).parameters
+
+
+def test_local_deploy_forces_no_verify_without_warning(tmp_path):
+    deploy = LocalDeploy(argparse.ArgumentParser())
+    main_file = tmp_path / "robot.py"
+    main_file.write_text("print('robot')")
+
+    fake_project = MagicMock()
+    fake_project.get_install_list.return_value = ["robotpy"]
+    fake_installer = MagicMock()
+    fake_installer.connect_to_robot.return_value.__enter__.return_value = (
+        LocalController()
+    )
+    fake_installer.connect_to_robot.return_value.__exit__.return_value = None
+
+    with (
+        patch("robotpy_installer.cli_deploy.pyproject.load", return_value=fake_project),
+        patch(
+            "robotpy_installer.cli_deploy.RobotpyInstaller", return_value=fake_installer
+        ),
+        patch.object(deploy, "_check_large_files", return_value=True),
+        patch.object(deploy, "_ensure_requirements"),
+        patch.object(deploy, "_do_deploy", return_value=True),
+        patch("robotpy_installer.cli_deploy.logger.warning") as warning,
+    ):
+        result = deploy.run(
+            main_file=main_file,
+            project_path=tmp_path,
+            debug=False,
+            ignore_image_version=False,
+            no_install=False,
+            no_uninstall=False,
+            force_install=False,
+            large=False,
+            cache_root=None,
+        )
+
+    assert result == 0
+    fake_project.are_local_requirements_met.assert_not_called()
+    warning.assert_not_called()
 
 
 def test_local_deploy_runs_local_without_tests_or_robot_class(tmp_path):
@@ -178,7 +225,6 @@ def test_local_deploy_runs_local_without_tests_or_robot_class(tmp_path):
                 debug=False,
                 ignore_image_version=False,
                 no_install=True,
-                no_verify=False,
                 no_uninstall=False,
                 force_install=False,
                 large=False,
@@ -192,6 +238,58 @@ def test_local_deploy_runs_local_without_tests_or_robot_class(tmp_path):
     assert fake_installer.connect_to_robot.call_args.kwargs["robot_or_team"] is None
     assert isinstance(
         fake_installer.connect_to_robot.call_args.kwargs["ssh"], LocalController
+    )
+
+
+def test_ensure_requirements_does_not_clear_packages_when_venv_missing():
+    deploy = Deploy(argparse.ArgumentParser())
+    fake_project = MagicMock()
+    fake_project.are_requirements_met.side_effect = [
+        (False, ["robotpy missing"]),
+        (True, []),
+        (True, []),
+    ]
+    fake_project.get_install_list.return_value = ["robotpy"]
+    fake_project.get_deploy_list.return_value = ["robotpy"]
+
+    fake_installer = MagicMock()
+    fake_installer.is_python_installed.return_value = True
+    fake_installer.get_python_version.return_value = required_pyversion
+
+    fake_ssh = MagicMock()
+    fake_ssh.sftp_remote_file_exists.return_value = False
+
+    with (
+        patch(
+            "robotpy_installer.cli_deploy.robot_utils.uninstall_cpp_java",
+            return_value=True,
+        ),
+        patch("robotpy_installer.cli_deploy.robot_utils.kill_robot_cmd", "true"),
+        patch("robotpy_installer.cli_deploy.yesno", return_value=True),
+        patch.object(deploy, "_get_robot_packages", return_value={}),
+        patch.object(deploy, "_get_cached_packages", return_value={}),
+        patch.object(deploy, "_clear_pip_packages") as clear_pip_packages,
+        patch("robotpy_installer.cli_deploy.logger.info") as info,
+    ):
+        deploy._ensure_requirements(
+            fake_project,
+            fake_installer,
+            fake_ssh,
+            no_install=False,
+            force_install=False,
+            no_uninstall=False,
+        )
+
+    fake_ssh.sftp_remote_file_exists.assert_any_call(_ROBOT_VENV)
+    clear_pip_packages.assert_not_called()
+    assert not any(
+        call.args
+        and call.args[0]
+        == "Clearing existing packages on robot before install (specify --no-uninstall to not do this)"
+        for call in info.call_args_list
+    )
+    fake_installer.pip_install.assert_called_once_with(
+        False, False, False, False, [], ["robotpy"]
     )
 
 

--- a/tests/test_local_deploy.py
+++ b/tests/test_local_deploy.py
@@ -1,0 +1,24 @@
+import pathlib
+
+from robotpy_installer.installer import RobotpyInstaller, _WPILIB_YEAR
+
+
+def test_installer_default_cache_root_is_wpilib_home():
+    installer = RobotpyInstaller(log_startup=False)
+
+    assert (
+        installer.cache_root
+        == pathlib.Path.home() / "wpilib" / _WPILIB_YEAR / "robotpy"
+    )
+    assert installer.pip_cache == installer.cache_root / "pip_cache"
+    assert installer.pkg_cache == installer.cache_root / "pkg_cache"
+
+
+def test_installer_cache_root_can_be_overridden(tmp_path):
+    cache_root = tmp_path / "cache"
+
+    installer = RobotpyInstaller(log_startup=False, cache_root=cache_root)
+
+    assert installer.cache_root == cache_root
+    assert installer.pip_cache == cache_root / "pip_cache"
+    assert installer.pkg_cache == cache_root / "pkg_cache"


### PR DESCRIPTION
In support of https://github.com/robotpy/robotpy-installer/issues/164. This is 100% slop courtesy of GPT 5.5, but it works. Will need to do some refactoring.

This was tested with a venv on systemcore using Python 3.11. It expects a fully loaded robotpy cache on the robot. Run the following commands to create the cache:

* `robotpy installer download-python --cache-root /path/to/cache`
* `robotpy installer download robotpy --cache-root /path/to/cache`

Copy the `/path/to/cache` to `/opt/blocks/cache` on systemcore.

To perform a local deploy, **as the systemcore user** run `robotpy deploy --local` on systemcore from the robot project's directory.